### PR TITLE
Default livesplit IP to localhost

### DIFF
--- a/dashboard/livesplit.html
+++ b/dashboard/livesplit.html
@@ -13,7 +13,7 @@
 		<div class="row">
 			<div class="col">
 				<label for="ip" class="form-label">IP</label>
-				<input type="text" id="ip" class="form-control form-select form-select-sm" value="192.168.0.47" />
+				<input type="text" id="ip" class="form-control form-select form-select-sm" value="localhost" />
 			</div>
 			<div class="col">
 				<label for="port" class="form-label">Port</label>


### PR DESCRIPTION
Most of the time, we use the livesplit on localhost

Replace current default arbitrary IP with localhost